### PR TITLE
Activity 라우터, 컨트롤러, 서비스, 레포지토리, 도메인 구현

### DIFF
--- a/server/Domain/Activity.js
+++ b/server/Domain/Activity.js
@@ -1,0 +1,10 @@
+class Activity {
+    constructor({id, userid, content, created_at}) {
+        this.id = id;
+        this.userid = userid;
+        this.content = content;
+        this.created_at = created_at;
+    }
+}
+
+module.exports = Activity;

--- a/server/Repository/ActivityRepository.js
+++ b/server/Repository/ActivityRepository.js
@@ -1,3 +1,5 @@
+const ActivityService = require("../services/activity-service");
+
 class ActivityRepository {
   constructor(activityDTO, db) {
     this.activityDTO = activityDTO;
@@ -35,15 +37,16 @@ class ActivityRepository {
   async createActivity(activityDTO) {
     const query =
       "INSERT INTO todo.Activities\
-        (userid, content, created_at)\
-        VALUES (?, ?, ?)";
-    const values = Object.values(activityDTO);
-    values.shift();
+        (userid, content)\
+        VALUES (?, ?)";
+    const [ , userid, content, ] = Object.values(activityDTO);
 
     try {
-      await this.db.query(query.values);
+      await this.db.query(query, [userid, content]);
     } catch (err) {
       throw err;
     }
   }
 }
+
+module.exports = ActivityRepository;

--- a/server/Repository/ActivityRepository.js
+++ b/server/Repository/ActivityRepository.js
@@ -1,0 +1,49 @@
+class ActivityRepository {
+  constructor(activityDTO, db) {
+    this.activityDTO = activityDTO;
+    this.db = db;
+  }
+
+  async findAllActivities() {
+    const [rows] = await this.db.query("SELECT * FROM todo.Activities");
+    const activities = rows.map((row) => {
+      return new this.activityDTO({
+        id: row.id,
+        userid: row.userid,
+        content: row.content,
+        created_at: row.created_at,
+      });
+    });
+    return activities;
+  }
+
+  async findActivityById(id) {
+    const query = "SELECT * FROM todo.Activities WHERE id=?";
+    const [rows] = await this.db.query(query, [id]);
+    const row = rows[0];
+
+    const activity = new this.activityDTO({
+      id: row.id,
+      userid: row.userid,
+      content: row.content,
+      created_at: row.created_at,
+    });
+
+    return activity;
+  }
+
+  async createActivity(activityDTO) {
+    const query =
+      "INSERT INTO todo.Activities\
+        (userid, content, created_at)\
+        VALUES (?, ?, ?)";
+    const values = Object.values(activityDTO);
+    values.shift();
+
+    try {
+      await this.db.query(query.values);
+    } catch (err) {
+      throw err;
+    }
+  }
+}

--- a/server/api.http
+++ b/server/api.http
@@ -26,3 +26,15 @@ Content-Type: application/json
 
 ### DELETE card api
 DELETE http://localhost:3000/api/card/4
+
+### GET all activity api
+GET http://localhost:3000/api/activity
+
+### POST activity api
+POST http://localhost:3000/api/activity HTTP/2.0
+Content-Type: application/json
+
+{
+    "userid": "1",
+    "content": "updated 데모 환경 설정"
+}

--- a/server/controllers/activity-controller.js
+++ b/server/controllers/activity-controller.js
@@ -1,0 +1,44 @@
+const Activity = require("../Domain/Activity");
+const ActivityRepository = require("../Repository/ActivityRepository");
+const ActivityService = require("../services/acitivity-service");
+const db = require("../db");
+
+async function getAllActivities(req, res, next) {
+  try {
+      const activityRepositoryInstance = new ActivityRepository(Activity, db);
+      const activityServiceInstance = new ActivityService(activityRepositoryInstance);
+
+      const fetchedActivities = await activityServiceInstance.fetchAllActivities();
+
+      res.status(200).send(fetchAllActivities);
+  } catch (error) {
+    console.error(error);
+    res.status(404).end();
+  }
+}
+
+async function createActivity(req, res, next) {
+    try {
+        const activity = new Activity({
+            id: req.body.id,
+            userid: req.body.userid,
+            content: req.body.content,
+            created_at: req.body.created_at,
+        });
+
+        const activityRepositoryInstance = new ActivityRepository(Activity, db);
+        const activityServiceInstance = new ActivityService(activityRepositoryInstance);
+
+        await activityServiceInstance.createActivity();
+
+        res.status(201).send("creating activity successed");
+    } catch (error) {
+        console.error(error);
+        res.status(404).send("creating activity has failed");
+    }
+}
+
+module.exports = {
+    getAllActivities,
+    createActivity,
+}

--- a/server/controllers/activity-controller.js
+++ b/server/controllers/activity-controller.js
@@ -1,6 +1,6 @@
 const Activity = require("../Domain/Activity");
 const ActivityRepository = require("../Repository/ActivityRepository");
-const ActivityService = require("../services/acitivity-service");
+const ActivityService = require("../services/activity-service");
 const db = require("../db");
 
 async function getAllActivities(req, res, next) {
@@ -10,7 +10,7 @@ async function getAllActivities(req, res, next) {
 
       const fetchedActivities = await activityServiceInstance.fetchAllActivities();
 
-      res.status(200).send(fetchAllActivities);
+      res.status(200).send(fetchedActivities);
   } catch (error) {
     console.error(error);
     res.status(404).end();
@@ -29,7 +29,7 @@ async function createActivity(req, res, next) {
         const activityRepositoryInstance = new ActivityRepository(Activity, db);
         const activityServiceInstance = new ActivityService(activityRepositoryInstance);
 
-        await activityServiceInstance.createActivity();
+        await activityServiceInstance.createActivity(activity);
 
         res.status(201).send("creating activity successed");
     } catch (error) {

--- a/server/routes/activity-router.js
+++ b/server/routes/activity-router.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const activityController = require("../controllers/activity-controller");
+
+router.get("/", activityController.fetchAllActivities);
+router.post("/", activityController.createActivity);
+
+module.exports = router;

--- a/server/routes/activity-router.js
+++ b/server/routes/activity-router.js
@@ -3,7 +3,7 @@ const router = express.Router();
 
 const activityController = require("../controllers/activity-controller");
 
-router.get("/", activityController.fetchAllActivities);
+router.get("/", activityController.getAllActivities);
 router.post("/", activityController.createActivity);
 
 module.exports = router;

--- a/server/routes/apiRouter.js
+++ b/server/routes/apiRouter.js
@@ -2,7 +2,9 @@ const express = require("express");
 const router = express.Router();
 
 const cardRouter = require('./cardRouter');
+const activityRouter = require("./activity-router");
 
 router.use("/card", cardRouter);
+router.use("/acitivity", activityRouter);
 
 module.exports = router;

--- a/server/routes/apiRouter.js
+++ b/server/routes/apiRouter.js
@@ -5,6 +5,6 @@ const cardRouter = require('./cardRouter');
 const activityRouter = require("./activity-router");
 
 router.use("/card", cardRouter);
-router.use("/acitivity", activityRouter);
+router.use("/activity", activityRouter);
 
 module.exports = router;

--- a/server/services/activity-service.js
+++ b/server/services/activity-service.js
@@ -3,7 +3,7 @@ class ActivityService {
     this.ActivityRepository = ActivityRepository;
   }
 
-  async fetchAllActivites() {
+  async fetchAllActivities() {
     const activities = await this.ActivityRepository.findAllActivities();
     return activities;
   }

--- a/server/services/activity-service.js
+++ b/server/services/activity-service.js
@@ -1,0 +1,20 @@
+class ActivityService {
+  constructor(ActivityRepository) {
+    this.ActivityRepository = ActivityRepository;
+  }
+
+  async fetchAllActivites() {
+    const activities = await this.ActivityRepository.findAllActivities();
+    return activities;
+  }
+
+  async createActivity(activityDTO) {
+    try {
+      await this.ActivityRepository.createActivity(activityDTO);
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+module.exports = ActivityService;


### PR DESCRIPTION
DB에서 Activity 레코드를 가져오고 새로운 레코드를 추가할 수 있도록

- `activity-router`
- `activity-controller`
- `activity-service`
- `activity-repository`
- `activity` (도메인)
을 구현했습니다.

이후 `activity-router`, `activity-controller` ,`activity-service` 는 deprecated 될 예정이며
해당 로직들을 `card-service`안으로 이전할 예정입니다.