### PR TITLE
Webpack development and production 설정

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ fi
 cd ./client
 
 echo "FE 빌드를 시작합니다..."
-npx webpack
+npm run build
 
 echo "빌드 된 결과 bundle 파일을 server의 public 디렉토리로 복사합니다"
 cp ./public/index_bundle.js ../server/public/

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3815,6 +3815,17 @@
         "wrap-ansi": "^5.1.0"
       }
     },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10112,6 +10123,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -11777,6 +11797,16 @@
         "uuid": "^3.3.2"
       }
     },
+    "webpack-merge": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.0.9.tgz",
+      "integrity": "sha512-P4teh6O26xIDPugOGX61wPxaeP918QOMjmzhu54zTVcLtOS28ffPWtnv+ilt3wscwBUCL2WNMnh97XkrKqt9Fw==",
+      "dev": true,
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -11857,6 +11887,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
     "word-wrap": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start:dev": "webpack-dev-server"
+    "start:dev": "webpack-dev-server --open --config webpack.dev.js",
+    "build": "webpack --config webpack.prod.js"
   },
   "keywords": [],
   "author": "",
@@ -28,7 +29,8 @@
     "supertest": "^4.0.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0",
+    "webpack-merge": "^5.0.9"
   },
   "dependencies": {
     "core-js": "^3.6.5"

--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -6,13 +6,7 @@ module.exports = {
     path: path.resolve(__dirname, "public"),
     filename: "index_bundle.js",
     publicPath: "public/",
-    sourceMapFilename: "index_bundle.js.map"
-  },
-  devtool: "eval",
-  devServer: {
-    contentBase: path.join(__dirname, "public"),
-    compress: true,
-    port: 9000,
+    sourceMapFilename: "index_bundle.js.map",
   },
   module: {
     rules: [

--- a/client/webpack.dev.js
+++ b/client/webpack.dev.js
@@ -1,0 +1,13 @@
+const commonConfig = require("./webpack.common");
+const path = require("path");
+const { merge } = require("webpack-merge");
+
+module.exports = merge(commonConfig, {
+  mode: "development",
+  devtool: "eval",
+  devServer: {
+    contentBase: path.join(__dirname, "public"),
+    compress: true,
+    port: 9000,
+  },
+});

--- a/client/webpack.prod.js
+++ b/client/webpack.prod.js
@@ -1,0 +1,6 @@
+const commonConfig = require("./webpack.common");
+const { merge } = require("webpack-merge");
+
+module.exports = merge(commonConfig, {
+  mode: "production",
+});


### PR DESCRIPTION
- webpack의 production과 development 환경에서 webpack의 공통적인 부분을 가져와 사용하기 위해 webpack-merge package devDependencies에 추가
- ./build.sh에 client production으로 build 하기 위해 명령어 수정
- webpack.config.js 파일을 webpack.common.js로 변경
- webpack 환경 분리를 위해 webpack.dev.js, webpack.prod.js 파일 추가